### PR TITLE
Integrate small module into ksun selinux_hide and other more minor changes

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -121,7 +121,7 @@ $(info -- KernelSU-Next Manager signature hash: $(KSU_NEXT_MANAGER_HASH))
 
 # RKSU: checks for available hook
 ## Logic flipped for HAVE_KSU_HOOK: 0 is success, 1 is failure
-HAVE_KSU_HOOK ?= 1
+HAVE_KSU_HOOK ?= 0
 
 # Checks hooks state
 ifeq ($(CONFIG_KSU_KPROBES_HOOK), y)

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -158,7 +158,7 @@ config KSU_SUSFS_SUS_MAP
 config KSU_SUSFS_SUS_MEMFD
     bool "Enable to hide or spoof suspicous memfd (experimental)"
     depends on KSU_SUSFS
-    default n
+    default y
     help
         - Allow preventing the user-defined memfd name from being created
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -44,8 +44,7 @@ config KSU_ALLOWLIST_WORKAROUND
 config KSU_MANUAL_HOOK
 	bool "KernelSU manual hook mode."
 	depends on KSU && KSU != m
-	default y if !KPROBES
-	default n
+	default y
 	help
 	  Enable manual hook support.
 
@@ -53,8 +52,7 @@ config KSU_KPROBES_HOOK
 	bool "KernelSU tracepoint+kretprobe hook"
 	depends on KSU && !KSU_MANUAL_HOOK
 	depends on KRETPROBES && KPROBES && HAVE_SYSCALL_TRACEPOINTS
-	default y if KPROBES && KRETPROBES && HAVE_SYSCALL_TRACEPOINTS
-	default y if !KSU_MANUAL_HOOK
+	default n
 	help
 	  Enable KPROBES, KRETPROBES and TRACEPOINT hook for KernelSU core.
 	  This should not be used on kernel below 5.10.

--- a/kernel/compat/kernel_compat.h
+++ b/kernel/compat/kernel_compat.h
@@ -100,7 +100,7 @@ static inline ssize_t __strscpy_pad(char *dest, const char *src, size_t count)
     if (count == 0)
         return -E2BIG;
 
-    strncpy(dest, src, count);
+    memcpy(dest, src, count);
     dest[count - 1] = '\0';
     return strlen(dest);
 #endif

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -517,13 +517,14 @@ init_hooks:
 	const char *init_adb_args[] = { "init", "adb_data_file", NULL };
 	ksu_add_shit_to_list(KSU_SEPOLICY_CMD_NORMAL_PERM, init_adb_args);
 
-    const char *kernel_adb_args[] = { "kernel", "adb_data_file", NULL };
-	ksu_add_shit_to_list(KSU_SEPOLICY_CMD_NORMAL_PERM, kernel_adb_args);
+	const char *adbroot_args[] = { "adbroot", "domain" };
+	ksu_add_shit_to_list(KSU_SEPOLICY_CMD_TYPE, adbroot_args);
 
+	const char *fsck_sys_admin_args[] = { "fsck_untrusted", "fsck_untrusted", "capability", "sys_admin" };
+	ksu_add_shit_to_list(KSU_SEPOLICY_CMD_XPERM, fsck_sys_admin_args);
 
-	// we move this to a module instead
-	// const char *adbroot_args[] = { "adbroot", NULL };
-	// ksu_add_shit_to_list(KSU_SEPOLICY_CMD_TYPE, adbroot_args);
+	const char *shell_su_args[] = { "shell", "su", "process", "transition" };
+	ksu_add_shit_to_list(KSU_SEPOLICY_CMD_TYPE_TRANSITION, shell_su_args);
 
 	ksu_selinux_hide_enable();
 	ksu_init_hook_selinux_transaction_write();

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -193,7 +193,7 @@ void ksu_sel_write_context(struct file **file, char **buf, size_t *size)
 	return;
 }
 
-#if defined(CONFIG_KPROBES)
+#ifdef CONFIG_KSU_KPROBES_HOOK
 
 #include <linux/kprobes.h>
 static struct kprobe *slow_avc_audit_kp;
@@ -240,7 +240,7 @@ static void destroy_kprobe(struct kprobe **kp_ptr)
 	kfree(kp);
 	*kp_ptr = NULL;
 }
-#endif // CONFIG_KPROBES
+#endif // CONFIG_KSU_KPROBES_HOOK
 
 
 static void ksu_selinux_hide_enable() 
@@ -249,7 +249,7 @@ static void ksu_selinux_hide_enable()
 	if (ret)
 		pr_info("selinux_hide: sid grab fail?\n");
 
-#if defined(CONFIG_KPROBES)
+#ifdef CONFIG_KSU_KPROBES_HOOK
 	slow_avc_audit_kp = init_kprobe("slow_avc_audit", slow_avc_audit_pre_handler);
 #endif
 
@@ -258,7 +258,7 @@ static void ksu_selinux_hide_enable()
 
 static void ksu_selinux_hide_disable()
 {
-#if defined(CONFIG_KPROBES)
+#ifdef CONFIG_KSU_KPROBES_HOOK
 	pr_info("selinux_hide: unregister slow_avc_audit kprobe!\n");
 	destroy_kprobe(&slow_avc_audit_kp);
 #endif

--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -429,7 +429,7 @@ int get_pkg_from_apk_path(char *pkg, const char *path)
 		return -1;
 
 	// Copying the package name
-	strncpy(pkg, second_last_slash + 1, pkg_len);
+	memcpy(pkg, second_last_slash + 1, pkg_len);
 	pkg[pkg_len] = '\0';
 
 	return 0;

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -312,7 +312,7 @@ static bool do_track_throne_core(bool prune_only)
 			break;
 		}
 		data->uid = res;
-		strncpy(data->package, package, KSU_MAX_PACKAGE_NAME);
+		strscpy(data->package, package, sizeof(data->package));
 		list_add_tail(&data->list, &uid_list);
 		// reset line start
 		line_start = pos;

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -94,7 +94,7 @@ static inline cpumask_t *ksu_get_current_cpumask_t() { return &current->cpus_all
 
 static int apply_kernelsu_rules_fn(void *ptr)
 {
-	struct policydb *db = (struct policydb *)ptr;
+    struct policydb *db = (struct policydb *)ptr;
 
     ksu_type(db, KERNEL_SU_DOMAIN, "domain");
     ksu_permissive(db, KERNEL_SU_DOMAIN);
@@ -118,33 +118,12 @@ static int apply_kernelsu_rules_fn(void *ptr)
         ksu_allowxperm(db, KERNEL_SU_DOMAIN, ALL, "file", ALL);
     }
 
-    // we need to save allowlist in /data/adb/ksu
-    ksu_allow(db, "kernel", "adb_data_file", "dir", ALL);
-    ksu_allow(db, "kernel", "adb_data_file", "file", ALL);
-    // we need to search /data/app
-    ksu_allow(db, "kernel", "apk_data_file", "file", "open");
-    ksu_allow(db, "kernel", "apk_data_file", "dir", "open");
-    ksu_allow(db, "kernel", "apk_data_file", "dir", "read");
-    ksu_allow(db, "kernel", "apk_data_file", "dir", "search");
-    // we may need to do mount on shell
-    ksu_allow(db, "kernel", "shell_data_file", "file", ALL);
-    // we need to read /data/system/packages.list
-    ksu_allow(db, "kernel", "kernel", "capability", "dac_override");
-    // Android 10+:
-    // http://aospxref.com/android-12.0.0_r3/xref/system/sepolicy/private/file_contexts#512
-    ksu_allow(db, "kernel", "packages_list_file", "file", ALL);
-    // Kernel 4.4
-    ksu_allow(db, "kernel", "packages_list_file", "dir", ALL);
-    // Android 9-:
-    // http://aospxref.com/android-9.0.0_r61/xref/system/sepolicy/private/file_contexts#360
-    ksu_allow(db, "kernel", "system_data_file", "file", ALL);
-    ksu_allow(db, "kernel", "system_data_file", "dir", ALL);
     // our ksud triggered by init
+    ksu_allow(db, "init", KERNEL_SU_DOMAIN, ALL, ALL);
+
+    // restored from https://github.com/tiann/KernelSU/pull/3031
     ksu_allow(db, "init", "adb_data_file", "file", ALL);
     ksu_allow(db, "init", "adb_data_file", "dir", ALL); // #1289
-    ksu_allow(db, "init", KERNEL_SU_DOMAIN, ALL, ALL);
-    // we need to umount modules in zygote
-    ksu_allow(db, "zygote", "adb_data_file", "dir", "search");
 
     // copied from Magisk rules
     // suRights
@@ -167,6 +146,18 @@ static int apply_kernelsu_rules_fn(void *ptr)
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "read");
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "open");
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "fifo_file", "getattr");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "read");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "write");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "connectto");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getopt");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getattr");
+
+    // use memfd created by su domain
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "execute");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "getattr");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "map");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "read");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "memfd_file", "write");
 
     // bootctl
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "dir", "search");
@@ -174,17 +165,13 @@ static int apply_kernelsu_rules_fn(void *ptr)
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "file", "open");
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "process", "getattr");
 
-    // For mounting loop devices, mirrors, tmpfs
-    ksu_allow(db, "kernel", ALL, "file", "read");
-    ksu_allow(db, "kernel", ALL, "file", "write");
-
     // Allow all binder transactions
     ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "binder", ALL);
 
     // Allow system server kill su process
     ksu_allow(db, "system_server", KERNEL_SU_DOMAIN, "process", "getpgid");
     ksu_allow(db, "system_server", KERNEL_SU_DOMAIN, "process", "sigkill");
-
+    
     return 0;
 }
 


### PR DESCRIPTION
The main one is the additional selinux_hide from small_module
Then changing rules.c as was very out of date
Removing strncpy though not much here (I'll put through another PR on your kernel)
Then I still think it should be CONFIG_KSU_KPROBES_HOOK instead of CONFIG_KPROBES for consistency with rest of KSUN
The enabling and disabling of configs iin Kcomfig is likely only useful to me and the minor build point is hardly worth mentioning!