### PR TITLE
Legacy susfs v2 pr clean

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -265,6 +265,9 @@ endif
 ifeq ($(shell grep -q "cpus_ptr;" $(srctree)/include/linux/sched.h; echo $$?),0)
 ccflags-y += -DKSU_COMPAT_HAS_BACKPORTED_CPUS_PTR
 endif
+ifeq ($(shell grep -q "struct pid \*task_pgrp" $(srctree)/include/linux/sched.h; echo $$?),0)
+ccflags-y += -DKSU_COMPAT_HAS_TASK_PGRP_FUNC
+endif
 
 # fallthrough check for allowlist v2
 ifneq ($(shell [ -f $(srctree)/include/linux/compiler_attributes.h ] && grep -q "define fallthrough" $(srctree)/include/linux/compiler_attributes.h; echo $$?),0)

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -93,6 +93,10 @@ int ksu_handle_faccessat(int *dfd, const char __user **filename_user,
 {
 	const char su[] = SU_PATH;
 
+	if (!ksu_su_compat_enabled) {
+		return 0;
+	}
+
 	if (!ksu_is_allow_uid_for_current(current_uid().val)) {
 		return 0;
 	}
@@ -114,6 +118,10 @@ int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags)
 {
 	// const char sh[] = SH_PATH;
 	const char su[] = SU_PATH;
+
+	if (!ksu_su_compat_enabled) {
+		return 0;
+	}
 
 	if (!ksu_is_allow_uid_for_current(current_uid().val)) {
 		return 0;
@@ -147,6 +155,9 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 	unsigned long addr;
 
 	if (unlikely(!filename_user))
+		goto do_orig_execve;
+
+	if (!ksu_su_compat_enabled)
 		goto do_orig_execve;
 
 	if (!ksu_is_allow_uid_for_current(current_uid().val))

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -231,7 +231,7 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	return 0;
 }
 
-/*int __ksu_handle_devpts(struct inode *inode)
+int __ksu_handle_devpts(struct inode *inode)
 {
 #ifndef KSU_KPROBES_HOOK
 	if (!ksu_su_compat_enabled)
@@ -258,11 +258,10 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	return 0;
 }
 
-// dead code: devpts handling
 int __maybe_unused ksu_handle_devpts(struct inode *inode)
 {
 	return __ksu_handle_devpts(inode);
-}*/
+}
 
 // sucompat: permitted process can execute 'su' to gain root access.
 void __init ksu_sucompat_init()

--- a/kernel/hook/lsm_hooks.c
+++ b/kernel/hook/lsm_hooks.c
@@ -10,6 +10,7 @@
 #include "compat/kernel_compat.h"
 #include "setuid_hook.h"
 #include "manager/throne_tracker.h"
+#include "ksu.h"
 
 #ifndef KSU_KPROBES_HOOK
 
@@ -29,6 +30,15 @@ static int ksu_key_permission(key_ref_t key_ref, const struct cred *cred,
 	}
 	init_session_keyring = cred->session_keyring;
 	pr_info("kernel_compat: got init_session_keyring\n");
+
+	// ksu_cred is prepare_creds()'d at driver init with no session keyring
+	// of its own, which makes privileged file ops done under it (e.g. the
+	// allowlist save in do_persistent_allow_list) fail with -ENOKEY. Give
+	// it init's, the same way a normal kernel thread would inherit one.
+	if (ksu_cred && init_session_keyring) {
+		key_get(init_session_keyring);
+		rcu_assign_pointer(ksu_cred->session_keyring, init_session_keyring);
+	}
 	return 0;
 }
 #endif

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -405,11 +405,17 @@ void track_throne(bool prune_only)
 		return;
 	}
 
-	// For asynchronous runs, if a work is already pending, canceling it
-	// ensures we don't clobber the prune_only state while it's waiting.
-	cancel_delayed_work_sync(&throne_data.dwork);
+	// Never flush/wait here: this is reachable from the pkg_observer
+	// fsnotify hook, which runs inside vfs_rename with the parent dir
+	// i_rwsem held, while the worker may be blocked in
+	// filp_open(packages.list) -> lookup_slow -> down_read on that same
+	// i_rwsem -- a sync cancel then deadlocks both sides in D state.
+	// Async cancel is sufficient: a mid-run worker finishes with the old
+	// prune_only, and the run queued below applies the new state (the
+	// worker's own retry reschedule is a no-op against pending work).
+	cancel_delayed_work(&throne_data.dwork);
 
-	// Update state safely and queue the new work
+	// Update state and queue the new work
 	throne_data.prune_only = prune_only;
 	throne_data.retries = 0;
 	schedule_delayed_work(&throne_data.dwork, 0);

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -10,8 +10,13 @@
 #include "objsec.h"
 #endif // #ifdef CONFIG_KSU_SUSFS
 #include <linux/thread_info.h>
+#include <linux/sched.h>
+#if __has_include(<linux/sched/task.h>)
 #include <linux/sched/task.h>
+#endif
+#if __has_include(<linux/sched/signal.h>)
 #include <linux/sched/signal.h>
+#endif
 #include "uapi/supercall.h"
 #include "supercall/internal.h"
 #include "arch.h" // IWYU pragma: keep
@@ -803,6 +808,15 @@ static int do_set_init_pgrp(void __user *arg)
 	write_lock_irq(&tasklist_lock);
 
 	p = current->group_leader;
+#ifdef KSU_COMPAT_HAS_TASK_PGRP_FUNC
+	init_group = task_pgrp(&init_task);
+
+	if (task_session(p) != task_session(&init_task))
+		goto out;
+
+	err = 0;
+	if (task_pgrp(p) != init_group) {
+#else
 	init_group = init_task.signal->pids[PIDTYPE_PGID];
 
 	if (p->signal->pids[PIDTYPE_SID] != init_task.signal->pids[PIDTYPE_SID])
@@ -810,6 +824,7 @@ static int do_set_init_pgrp(void __user *arg)
 
 	err = 0;
 	if (p->signal->pids[PIDTYPE_PGID] != init_group) {
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
         change_pid(pids, p, PIDTYPE_PGID, init_group);
 #else

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -10,6 +10,8 @@
 #include "objsec.h"
 #endif // #ifdef CONFIG_KSU_SUSFS
 #include <linux/thread_info.h>
+#include <linux/sched/task.h>
+#include <linux/sched/signal.h>
 #include "uapi/supercall.h"
 #include "supercall/internal.h"
 #include "arch.h" // IWYU pragma: keep
@@ -799,15 +801,15 @@ static int do_set_init_pgrp(void __user *arg)
 #endif
 
 	write_lock_irq(&tasklist_lock);
-	
-	p = current->group_leader;
-	init_group = task_pgrp(&init_task);
 
-	if (task_session(p) != task_session(&init_task))
+	p = current->group_leader;
+	init_group = init_task.signal->pids[PIDTYPE_PGID];
+
+	if (p->signal->pids[PIDTYPE_SID] != init_task.signal->pids[PIDTYPE_SID])
 		goto out;
 
 	err = 0;
-	if (task_pgrp(p) != init_group) {
+	if (p->signal->pids[PIDTYPE_PGID] != init_group) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
         change_pid(pids, p, PIDTYPE_PGID, init_group);
 #else


### PR DESCRIPTION
6 independent fixes found while porting this branch to two downstream devices
  (msm-4.9 and msm-4.14). All compile-verified; also verified live on
  device. No device-specific values included — see notes per commit.

  - b8644118 / 1502e4d8 — supercall: task_pgrp/task_session compat
    msm-4.14 has no task_pgrp()/task_session() helpers and no tasklist_lock
    reachable the way this code expected; msm-4.9 has the opposite problem
    (real inline helpers, no signal->pids[] array). 1502e4d8 replaces the
    original hardcoded msm-4.14 fix with a Kbuild grep probe
    (KSU_COMPAT_HAS_TASK_PGRP_FUNC) so both tree shapes are supported without
    hardcoding for one. Compile-verified on both trees.

  - 0de8ed2e — sucompat: restore ksu_handle_devpts
    Was commented out as "dead code" on this branch, but fs/devpts/inode.c
    calls it unconditionally under CONFIG_KSU, so any tree that still wires
    devpts through KSU fails to link/behaves wrong without it.

  - 6a13a609 — sucompat: ksu_su_compat_enabled guard
    faccessat/stat/execve handlers were missing the enabled-check that
    execveat already had, so su compat hooks could still fire after being
    toggled off.

  - 6adedaeb — manager/throne_tracker: fix ABBA deadlock
    cancel_delayed_work_sync() in track_throne() could block against the
    pkg_observer fsnotify hook during a packages.list rename, freezing the
    whole device. Switched to the non-blocking cancel_delayed_work().
    Reproduced and fixed on a real packages.list churn stress test.

  - ed83148e — lsm_hooks: apply captured init_session_keyring to ksu_cred
    CONFIG_KSU_ALLOWLIST_WORKAROUND (and the <4.10 kernel path) captures
    init's session keyring in ksu_key_permission() but never applies it to
    ksu_cred, so any privileged file op done under override_creds(ksu_cred) —
    including the allowlist save itself — fails silently with -ENOKEY. This
    is why root grants weren't surviving reboot on affected kernels. Fixed by
    giving ksu_cred a reference to init's keyring, the same way a kernel
    thread would inherit one. Reproduced (dmesg: "save_allow_list create file
    failed: -126") and confirmed fixed with a full grant → reboot → verify
    cycle on device.

  Branch: legacy-susfs-v2-pr-clean, based on this repo's legacy-susfs-v2 tip
  (f110cddc). Deliberately excludes two commits we also carry downstream that
  are specific to our own multi-device fork (a manager-cert override for one
  ROM's resigned manager APK, and the build-time mechanism to make that
  overridable) — neither is relevant upstream since you only ship one manager.

  The branch is legacy-susfs-v2-pr-clean on i928/KSU-Next, based against sidex15/KernelSU-Next:legacy-susfs-v2.
